### PR TITLE
Use time.Duration as type for delay

### DIFF
--- a/client/api/events.go
+++ b/client/api/events.go
@@ -1,11 +1,13 @@
 package api
 
+import "time"
+
 // CompileEvent is the individual event structure
 // as returned by play.golang.org
 type CompileEvent struct {
 	Message string
 	Kind    string
-	Delay   int
+	Delay   time.Duration
 }
 
 // CompileResponse is the entire /compile response payload structure

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const staticDir = "../static"
@@ -35,7 +36,7 @@ type FmtResponse struct {
 type CompileEvent struct {
 	Message string
 	Kind    string
-	Delay   int
+	Delay   time.Duration
 }
 
 // CompileResponse is the response returned from


### PR DESCRIPTION
Fixes integer overflows on durations longer than 2147483647 nanoseconds (2.15 seconds) on 32-bit machines.

This could also be achieved by using int64, but time.Duration is clearer.

<img width="1440" alt="screen shot 2017-06-05 at 22 29 20" src="https://cloud.githubusercontent.com/assets/1525809/26804102/b5d9677e-4a3e-11e7-841f-6388cde124ad.png">

